### PR TITLE
Focus browser tab on selection

### DIFF
--- a/manifest-chromium.json
+++ b/manifest-chromium.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Canvas Browser Extension",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Seamlessly sync browser tabs with Canvas server contexts",
 
   "permissions": [

--- a/manifest-firefox.json
+++ b/manifest-firefox.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Canvas Browser Extension",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Seamlessly sync browser tabs with Canvas server contexts",
 
   "permissions": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "canvas-browser-extension",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Canvas Browser Extension for seamless tab synchronization",
   "type": "module",
   "scripts": {

--- a/src/background/modules/tab-manager.js
+++ b/src/background/modules/tab-manager.js
@@ -289,6 +289,19 @@ export class TabManager {
     }
   }
 
+  // Focus tab
+  async focusTab(tabId) {
+    try {
+      const tab = await chrome.tabs.get(tabId);
+      await chrome.tabs.update(tabId, { active: true });
+      await chrome.windows.update(tab.windowId, { focused: true });
+      return true;
+    } catch (error) {
+      console.error('Failed to focus tab:', error);
+      return false;
+    }
+  }
+
   // Close multiple tabs
   async closeTabs(tabIds) {
     try {

--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -570,6 +570,11 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       handleCloseTab(message.data, sendResponse);
       return true;
 
+    case 'FOCUS_TAB':
+      // Focus browser tab
+      handleFocusTab(message.data, sendResponse);
+      return true;
+
     case 'TOGGLE_PIN_TAB':
       // Toggle pin state of a tab
       handleTogglePinTab(message.data, sendResponse);
@@ -923,6 +928,37 @@ async function handleCloseTab(data, sendResponse) {
     }
   } catch (error) {
     console.error('Failed to close tab:', error);
+    sendResponse({
+      success: false,
+      error: error.message
+    });
+  }
+}
+
+async function handleFocusTab(data, sendResponse) {
+  try {
+    const { tabId } = data;
+
+    if (!tabId) {
+      throw new Error('Tab ID is required');
+    }
+
+    console.log('Focusing tab:', tabId);
+
+    // Focus the tab using Chrome API
+    const result = await tabManager.focusTab(tabId);
+
+    if (result) {
+      console.log('Tab focused successfully:', tabId);
+      sendResponse({
+        success: true,
+        message: 'Tab focused successfully'
+      });
+    } else {
+      throw new Error('Failed to focus tab');
+    }
+  } catch (error) {
+    console.error('Failed to focus tab:', error);
     sendResponse({
       success: false,
       error: error.message

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -393,6 +393,12 @@ body {
 .tab-info {
   flex: 1;
   min-width: 0;
+  cursor: pointer;
+  transition: opacity 0.2s ease;
+}
+
+.tab-info:hover {
+  opacity: 0.8;
 }
 
 .tab-title {

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -1175,6 +1175,21 @@ async function handlePinTab(tabId) {
   }
 }
 
+async function handleFocusTab(tabId) {
+  try {
+    console.log('Focusing tab:', tabId);
+
+    const response = await sendMessageToBackground('FOCUS_TAB', { tabId });
+    console.log('Focus tab response:', response);
+
+    if (!response.success) {
+      console.error('Failed to focus tab:', response.error);
+    }
+  } catch (error) {
+    console.error('Failed to focus tab:', error);
+  }
+}
+
 async function handleOpenCanvasTab(documentId) {
   try {
     console.log('Opening Canvas document:', documentId);
@@ -1261,36 +1276,54 @@ function handleBrowserTabAction(event) {
   const button = event.target.closest('button[data-action]');
   console.log('Found button:', button);
 
-  if (!button) return;
+  // Check if it's a button action
+  if (button) {
+    event.preventDefault();
+    event.stopPropagation();
 
-  event.preventDefault();
-  event.stopPropagation();
+    const action = button.dataset.action;
+    const tabId = parseInt(button.dataset.tabId);
 
-  const action = button.dataset.action;
-  const tabId = parseInt(button.dataset.tabId);
+    console.log('Action:', action, 'TabId:', tabId);
 
-  console.log('Action:', action, 'TabId:', tabId);
+    if (!tabId) {
+      console.error('No tabId found for action:', action);
+      return;
+    }
 
-  if (!tabId) {
-    console.error('No tabId found for action:', action);
+    switch (action) {
+      case 'sync':
+        console.log('Calling handleSyncTab with tabId:', tabId);
+        handleSyncTab(tabId);
+        break;
+      case 'close':
+        console.log('Calling handleCloseTab with tabId:', tabId);
+        handleCloseTab(tabId);
+        break;
+      case 'pin':
+        console.log('Calling handlePinTab with tabId:', tabId);
+        handlePinTab(tabId);
+        break;
+      default:
+        console.warn('Unknown browser tab action:', action);
+    }
     return;
   }
 
-  switch (action) {
-    case 'sync':
-      console.log('Calling handleSyncTab with tabId:', tabId);
-      handleSyncTab(tabId);
-      break;
-    case 'close':
-      console.log('Calling handleCloseTab with tabId:', tabId);
-      handleCloseTab(tabId);
-      break;
-    case 'pin':
-      console.log('Calling handlePinTab with tabId:', tabId);
-      handlePinTab(tabId);
-      break;
-    default:
-      console.warn('Unknown browser tab action:', action);
+  // Check if it's a click on the tab info area (for focusing)
+  const tabInfo = event.target.closest('.tab-info');
+  const tabItem = event.target.closest('.tab-item');
+  
+  if (tabInfo && tabItem) {
+    const tabId = parseInt(tabItem.dataset.tabId);
+    
+    console.log('Tab info clicked, focusing tab:', tabId);
+    
+    if (tabId) {
+      event.preventDefault();
+      event.stopPropagation();
+      handleFocusTab(tabId);
+    }
   }
 }
 


### PR DESCRIPTION
Enable focusing on a browser tab by clicking its title in the extension's tab list, allowing quick navigation.

---
<a href="https://cursor.com/background-agent?bcId=bc-a578309a-2d62-455c-8494-ddf151c53bc2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a578309a-2d62-455c-8494-ddf151c53bc2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

