### PR TITLE
Fix browser extension https connection

### DIFF
--- a/manifest-firefox.json
+++ b/manifest-firefox.json
@@ -13,7 +13,28 @@
   "host_permissions": [
     "http://localhost/*",
     "http://127.0.0.1/*",
-    "https://*/*"
+    "http://10.0.0.0/*",
+    "http://10.*/*",
+    "http://172.16.*/*",
+    "http://172.17.*/*",
+    "http://172.18.*/*",
+    "http://172.19.*/*",
+    "http://172.20.*/*",
+    "http://172.21.*/*",
+    "http://172.22.*/*",
+    "http://172.23.*/*",
+    "http://172.24.*/*",
+    "http://172.25.*/*",
+    "http://172.26.*/*",
+    "http://172.27.*/*",
+    "http://172.28.*/*",
+    "http://172.29.*/*",
+    "http://172.30.*/*",
+    "http://172.31.*/*",
+    "http://192.168.*/*",
+    "https://*/*",
+    "https://my.cnvs.ai/*",
+    "https://canvas.idnc.sk/*"
   ],
 
   "background": {
@@ -41,7 +62,7 @@
   },
 
   "content_security_policy": {
-    "extension_pages": "script-src 'self'; object-src 'self'; connect-src 'self' http://localhost:* http://127.0.0.1:* https://* ws://localhost:* ws://127.0.0.1:* wss://*; style-src 'self' 'unsafe-inline';"
+    "extension_pages": "script-src 'self'; object-src 'self'; connect-src 'self' http://localhost:* http://127.0.0.1:* http://10.0.0.0:* http://10.*:* http://172.16.*:* http://172.17.*:* http://172.18.*:* http://172.19.*:* http://172.20.*:* http://172.21.*:* http://172.22.*:* http://172.23.*:* http://172.24.*:* http://172.25.*:* http://172.26.*:* http://172.27.*:* http://172.28.*:* http://172.29.*:* http://172.30.*:* http://172.31.*:* http://192.168.*:* https: ws://localhost:* ws://127.0.0.1:* ws://10.0.0.0:* ws://10.*:* ws://172.16.*:* ws://172.17.*:* ws://172.18.*:* ws://172.19.*:* ws://172.20.*:* ws://172.21.*:* ws://172.22.*:* ws://172.23.*:* ws://172.24.*:* ws://172.25.*:* ws://172.26.*:* ws://172.27.*:* ws://172.28.*:* ws://172.29.*:* ws://172.30.*:* ws://172.31.*:* ws://192.168.*:* wss:; style-src 'self' 'unsafe-inline';"
   },
 
   "web_accessible_resources": [


### PR DESCRIPTION
Expand Firefox manifest host permissions and CSP to allow connections to all HTTPS and local network canvas-server instances.

---
<a href="https://cursor.com/background-agent?bcId=bc-f3b627e3-890e-445a-b1e7-daa844c4a42b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f3b627e3-890e-445a-b1e7-daa844c4a42b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

