### PR TITLE
Update context binding UI indicators

### DIFF
--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -108,6 +108,10 @@ body {
   background: #28a745;
 }
 
+.status-dot.unbound {
+  background: #6c757d;
+}
+
 .status-text {
   font-size: 12px;
   font-weight: 500;

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -435,8 +435,13 @@ function updateConnectionStatus(connection) {
       console.log('Popup: Context mode, workspace info:', connection.workspace);
       
       // Create green dot indicator for bound state
-      const boundIndicator = '<span class="status-dot connected" style="margin-right: 6px;"></span>';
-      contextId.innerHTML = `${boundIndicator}Bound to context ID: ${connection.context.id}`;
+      contextId.textContent = '';
+      const boundIndicator = createSecureElement('span', {
+        className: 'status-dot connected',
+        style: 'margin-right: 6px;'
+      });
+      contextId.appendChild(boundIndicator);
+      contextId.appendChild(document.createTextNode(`Bound to context ID: ${escapeHtml(connection.context.id)}`));
 
       // Get workspace name from context or use fallback
       const workspaceName = connection.context.workspaceName || connection.context.workspace ||
@@ -458,8 +463,13 @@ function updateConnectionStatus(connection) {
       console.log('Popup: Explorer mode, workspace:', wsName);
       
       // Create gray dot indicator for unbound state (explorer mode is not bound - no dynamic updates)
-      const unboundIndicator = '<span class="status-dot unbound" style="margin-right: 6px;"></span>';
-      contextId.innerHTML = `${unboundIndicator}Current workspace: ${wsName}`;
+      contextId.textContent = '';
+      const unboundIndicator = createSecureElement('span', {
+        className: 'status-dot unbound',
+        style: 'margin-right: 6px;'
+      });
+      contextId.appendChild(unboundIndicator);
+      contextId.appendChild(document.createTextNode(`Current workspace: ${escapeHtml(wsName)}`));
 
       // Format URL as workspace.name://path
       const workspacePath = currentWorkspacePath || '/';
@@ -469,8 +479,13 @@ function updateConnectionStatus(connection) {
       console.log('Popup: No context or workspace selected');
       
       // Create gray button indicator for unbound state
-      const unboundIndicator = '<span class="status-dot unbound" style="margin-right: 6px;"></span>';
-      contextId.innerHTML = `${unboundIndicator}-`;
+      contextId.textContent = '';
+      const unboundIndicator = createSecureElement('span', {
+        className: 'status-dot unbound',
+        style: 'margin-right: 6px;'
+      });
+      contextId.appendChild(unboundIndicator);
+      contextId.appendChild(document.createTextNode('-'));
       contextUrl.textContent = 'Not bound';
       contextUrl.classList.remove('clickable');
     }
@@ -480,8 +495,13 @@ function updateConnectionStatus(connection) {
     connectionText.textContent = 'Disconnected';
     
     // Create gray button indicator for unbound state when disconnected
-    const unboundIndicator = '<span class="status-dot unbound" style="margin-right: 6px;"></span>';
-    contextId.innerHTML = `${unboundIndicator}-`;
+    contextId.textContent = '';
+    const unboundIndicator = createSecureElement('span', {
+      className: 'status-dot unbound',
+      style: 'margin-right: 6px;'
+    });
+    contextId.appendChild(unboundIndicator);
+    contextId.appendChild(document.createTextNode('-'));
     contextUrl.textContent = 'No context';
     contextUrl.classList.remove('clickable');
   }

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -457,9 +457,9 @@ function updateConnectionStatus(connection) {
       const wsName = getWorkspaceName(connection.workspace);
       console.log('Popup: Explorer mode, workspace:', wsName);
       
-      // Create green dot indicator for bound state (explorer mode is also considered "bound")
-      const boundIndicator = '<span class="status-dot connected" style="margin-right: 6px;"></span>';
-      contextId.innerHTML = `${boundIndicator}Current workspace: ${wsName}`;
+      // Create gray dot indicator for unbound state (explorer mode is not bound - no dynamic updates)
+      const unboundIndicator = '<span class="status-dot unbound" style="margin-right: 6px;"></span>';
+      contextId.innerHTML = `${unboundIndicator}Current workspace: ${wsName}`;
 
       // Format URL as workspace.name://path
       const workspacePath = currentWorkspacePath || '/';

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -433,7 +433,10 @@ function updateConnectionStatus(connection) {
     if ((connection.mode === 'context') && connection.context) {
       console.log('Popup: Context mode, context:', connection.context);
       console.log('Popup: Context mode, workspace info:', connection.workspace);
-      contextId.textContent = `Bound to context ID: ${connection.context.id}`;
+      
+      // Create green dot indicator for bound state
+      const boundIndicator = '<span class="status-dot connected" style="margin-right: 6px;"></span>';
+      contextId.innerHTML = `${boundIndicator}Bound to context ID: ${connection.context.id}`;
 
       // Get workspace name from context or use fallback
       const workspaceName = connection.context.workspaceName || connection.context.workspace ||
@@ -453,7 +456,10 @@ function updateConnectionStatus(connection) {
     } else if ((connection.mode === 'explorer') && connection.workspace) {
       const wsName = getWorkspaceName(connection.workspace);
       console.log('Popup: Explorer mode, workspace:', wsName);
-      contextId.textContent = `Current workspace: ${wsName}`;
+      
+      // Create green dot indicator for bound state (explorer mode is also considered "bound")
+      const boundIndicator = '<span class="status-dot connected" style="margin-right: 6px;"></span>';
+      contextId.innerHTML = `${boundIndicator}Current workspace: ${wsName}`;
 
       // Format URL as workspace.name://path
       const workspacePath = currentWorkspacePath || '/';
@@ -461,7 +467,10 @@ function updateConnectionStatus(connection) {
       contextUrl.classList.add('clickable');
     } else {
       console.log('Popup: No context or workspace selected');
-      contextId.textContent = '-';
+      
+      // Create gray button indicator for unbound state
+      const unboundIndicator = '<span class="status-dot unbound" style="margin-right: 6px;"></span>';
+      contextId.innerHTML = `${unboundIndicator}-`;
       contextUrl.textContent = 'Not bound';
       contextUrl.classList.remove('clickable');
     }
@@ -469,7 +478,10 @@ function updateConnectionStatus(connection) {
     console.log('Popup: Setting status to DISCONNECTED');
     connectionStatus.className = 'status-dot disconnected';
     connectionText.textContent = 'Disconnected';
-    contextId.textContent = '-';
+    
+    // Create gray button indicator for unbound state when disconnected
+    const unboundIndicator = '<span class="status-dot unbound" style="margin-right: 6px;"></span>';
+    contextId.innerHTML = `${unboundIndicator}-`;
     contextUrl.textContent = 'No context';
     contextUrl.classList.remove('clickable');
   }


### PR DESCRIPTION
Add visual indicators (green/gray dots) to the context ID to streamline UI/UX for canvas integrations.

---
<a href="https://cursor.com/background-agent?bcId=bc-3a2d9121-c9e0-4b00-a482-95c2bc0120c2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3a2d9121-c9e0-4b00-a482-95c2bc0120c2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

