### PR TITLE
Auto-update recent items in send to canvas menu

### DIFF
--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -2478,6 +2478,8 @@ if (contextMenusAPI && contextMenusAPI.onClicked) {
                 title: currentContext.url || contextId
               });
             }
+            // Refresh context menus to update recent destinations list
+            await setupContextMenus();
           } else {
             console.error('Failed to sync tab to current context:', result.error);
           }
@@ -2522,6 +2524,9 @@ if (contextMenusAPI && contextMenusAPI.onClicked) {
                 contextSpec: contextSpec,
                 title: `${workspaceName}${contextSpec}`
               });
+              
+              // Refresh context menus to update recent destinations list
+              await setupContextMenus();
             } else {
               console.error('Failed to sync tab via context menu:', response.message);
             }
@@ -2555,6 +2560,8 @@ if (contextMenusAPI && contextMenusAPI.onClicked) {
                 title: existingDest.title
               });
             }
+            // Refresh context menus to update recent destinations list
+            await setupContextMenus();
           } else {
             console.error('Failed to sync tab to recent context:', result.error);
           }
@@ -2599,6 +2606,9 @@ if (contextMenusAPI && contextMenusAPI.onClicked) {
                 contextSpec: contextSpec,
                 title: `${workspaceName}${contextSpec}`
               });
+              
+              // Refresh context menus to update recent destinations list
+              await setupContextMenus();
             } else {
               console.error('Failed to sync tab via context menu:', response.message);
             }
@@ -2649,6 +2659,9 @@ if (contextMenusAPI && contextMenusAPI.onClicked) {
                 contextSpec: contextSpec,
                 title: `${workspaceName}${contextSpec}`
               });
+              
+              // Refresh context menus to update recent destinations list
+              await setupContextMenus();
             } else {
               console.error('Failed to sync tab via context menu:', response.message);
             }


### PR DESCRIPTION
Refresh the "Recent:" list in the "Send page to Canvas" context menu immediately after a document is inserted.

The context menu's "Recent:" list was not updating automatically when a page was sent to Canvas via the context menu. This fix ensures `setupContextMenus()` is called after each successful document insertion, mirroring the existing auto-update behavior for tree structure changes.

---
<a href="https://cursor.com/background-agent?bcId=bc-61c3abd7-7737-4139-ae13-80b5d322b353"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-61c3abd7-7737-4139-ae13-80b5d322b353"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

