### PR TITLE
Filter active workspaces in explorer mode

### DIFF
--- a/manifest-chromium.json
+++ b/manifest-chromium.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Canvas Browser Extension",
-  "version": "2.0.12",
+  "version": "2.1.0",
   "description": "Seamlessly sync browser tabs with Canvas server contexts",
 
   "permissions": [

--- a/manifest-firefox.json
+++ b/manifest-firefox.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Canvas Browser Extension",
-  "version": "2.0.12",
+  "version": "2.1.0",
   "description": "Seamlessly sync browser tabs with Canvas server contexts",
 
   "permissions": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "canvas-browser-extension",
-  "version": "2.0.12",
+  "version": "2.1.0",
   "description": "Canvas Browser Extension for seamless tab synchronization",
   "type": "module",
   "scripts": {

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -1885,7 +1885,17 @@ function renderWorkspacesList(workspaces) {
     return;
   }
 
-  const workspacesHtml = workspaces.map(workspace => `
+  // Filter workspaces to only show those with status "active"
+  const activeWorkspaces = workspaces.filter(workspace => workspace.status === 'active');
+
+  if (activeWorkspaces.length === 0) {
+    const emptyDiv = createSecureElement('div', { className: 'empty-state' }, 'No active workspaces available');
+    workspacesList.textContent = '';
+    workspacesList.appendChild(emptyDiv);
+    return;
+  }
+
+  const workspacesHtml = activeWorkspaces.map(workspace => `
     <div class="selection-item" data-workspace-id="${workspace.id}">
       <div class="selection-item-info">
         <div class="selection-item-name">${workspace.label || workspace.name || workspace.id}</div>


### PR DESCRIPTION
Only show active workspaces in the browser extension popup's Explorer mode to fix a display bug.

---
<a href="https://cursor.com/background-agent?bcId=bc-d9dd0a55-6197-4e99-92aa-0aba5b130b4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d9dd0a55-6197-4e99-92aa-0aba5b130b4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

